### PR TITLE
Use correct ENABLE_GPxxx macros when enabling parsers

### DIFF
--- a/src/nmea/parser_static.c
+++ b/src/nmea/parser_static.c
@@ -23,10 +23,10 @@
 #ifdef ENABLE_GPGLL
 DECLARE_PARSER_API(gpgll)
 #endif
-#ifdef ENABLE_GPGLL
+#ifdef ENABLE_GPGGA
 DECLARE_PARSER_API(gpgga)
 #endif
-#ifdef ENABLE_GPGLL
+#ifdef ENABLE_GPRMC
 DECLARE_PARSER_API(gprmc)
 #endif
 
@@ -48,10 +48,10 @@ nmea_load_parsers()
 #ifdef ENABLE_GPGLL
 	PARSER_LOAD(gpgll);
 #endif
-#ifdef ENABLE_GPGLL
+#ifdef ENABLE_GPGGA
 	PARSER_LOAD(gpgga);
 #endif
-#ifdef ENABLE_GPGLL
+#ifdef ENABLE_GPRMC
 	PARSER_LOAD(gprmc);
 #endif
 


### PR DESCRIPTION
Hi @jacketizer, thank you for a very useful library!

While cross-compiling libnmea for a microcontroller environment (hence using a custom makefile), I have noticed that ENABLE_GPxxx macros were not working as expected.