### PR TITLE
Fix PARSER_CNT evaluation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifdef NMEA_STATIC
 SRC_FILES=src/nmea/nmea.c src/nmea/parser_static.c
 PARSER_DEF=$(shell echo "$(NMEA_STATIC)" | sed -e 's/^/-DENABLE_/g' -e 's/,/ -DENABLE_/g')
-PARSER_CNT=$(shell echo "$(NMEA_STATIC)" | sed 's/,/\n/g' | wc -l)
+PARSER_CNT=$(shell echo "$(NMEA_STATIC)" | sed 's/,/ /g' | wc -w | tr -d ' ')
 else
 SRC_FILES=src/nmea/nmea.c src/nmea/parser.c
 endif


### PR DESCRIPTION
On macOS, sed does not treat '\n' as one would expect, producing a single line of output. Using a literal newline seems to be a portable solution for this problem (see e.g. http://nlfiedler.github.io/2010/12/05/newlines-in-sed-on-mac.html), but looks atrocious inside a
makefile. 
Replace commas with spaces, and count number of words instead.

In addition to that, on macOS `wc` will right pad the number, which causes `PARSER_CNT` to be set to something like "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2", breaking `-DPARSER_CNT=$(PARSER_CNT)` expression later.
Use `tr` to remove the extra whitespace.