### PR TITLE
Add support for parsing speed

### DIFF
--- a/src/parsers/gprmc.c
+++ b/src/parsers/gprmc.c
@@ -86,6 +86,12 @@ parse(nmea_parser_s *parser, char *value, int val_index)
 		}
 		break;
 
+	case NMEA_GPRMC_SPEED:
+		/* Parse ground speed in knots */
+		/* TODO: use strtod to do the conversion with error checking */
+		data->speed = atof(value);
+		break;
+
 	default:
 		break;
 	}

--- a/src/parsers/gprmc.h
+++ b/src/parsers/gprmc.h
@@ -10,6 +10,7 @@ typedef struct {
 	nmea_s base;
 	nmea_position longitude;
 	nmea_position latitude;
+	double speed;
 	struct tm time;
 } nmea_gprmc_s;
 
@@ -20,5 +21,5 @@ typedef struct {
 #define NMEA_GPRMC_LONGITUDE_CARDINAL	5
 #define NMEA_GPRMC_TIME			0
 #define NMEA_GPRMC_DATE			8
-
+#define NMEA_GPRMC_SPEED		6
 #endif  /* INC_NMEA_GPRMC_H */


### PR DESCRIPTION
RMC sentence contains speed over ground in knots.
Parse it out as a double using atof.

Per -
    http://aprs.gids.nl/nmea/#rmc
and
    http://www.gpsinformation.org/dale/nmea.htm#RMC

Example:
$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A

Where:
     RMC          Recommended Minimum sentence C
     123519       Fix taken at 12:35:19 UTC
     A            Status A=active or V=Void.
     4807.038,N   Latitude 48 deg 07.038' N
     01131.000,E  Longitude 11 deg 31.000' E
     022.4        Speed over the ground in knots
     084.4        Track angle in degrees True
     230394       Date - 23rd of March 1994
     003.1,W      Magnetic Variation
     *6A          The checksum data, always begins with *