### PR TITLE
add new test for odd applanix time parsing

### DIFF
--- a/tests/unit-tests/test_parse.c
+++ b/tests/unit-tests/test_parse.c
@@ -145,6 +145,13 @@ test_time_parse_ok()
 	mu_assert("t.tm_min should be 8", 8 == t.tm_min);
 	mu_assert("t.tm_hour should be 9", 9 == t.tm_hour);
 
+	/* Parse time, Applanix trailing zeros */
+	rv = nmea_time_parse("151148.00", &t);
+	mu_assert("should return 0 on success", 0 == rv);
+	mu_assert("t.tm_sec should be 48", 48 == t.tm_sec);
+	mu_assert("t.tm_min should be 11", 11 == t.tm_min);
+	mu_assert("t.tm_hour should be 15", 15 == t.tm_hour);
+
 	return 0;
 }
 


### PR DESCRIPTION
I encountered an odd thing with a GPRMC sentence coming from an APX15. The time stamp was formatted as a floating point and had trailing zeros. Thought it would be interesting to have a test for that case (it passes). Here is a sample sentence.
```
$GPRMC,151148.00,A,4528.39932766,N,07335.43007565,W,4.122,303.949,171218,14.3542,W,A*3F
```

I might also submit a PR for the new "fix mode" field that [can appear right before the checksum](https://www.gpsinformation.org/dale/nmea.htm#2.3):

> The last version 2 iteration of the NMEA standard was 2.3. It added a mode indicator to several sentences which is used to indicate the kind of fix the receiver currently has. This indication is part of the signal integrity information needed by the FAA. The value can be A=autonomous, D=differential, E=Estimated, N=not valid, S=Simulator. Sometimes there can be a null value as well. Only the A and D values will correspond to an Active and reliable Sentence. This mode character has been added to the RMC, RMB, VTG, and GLL, sentences and optionally some others including the BWC and XTE sentences.

Edit: I think the sentence I posted above is actually non-standard as it goes over the maximum allowed characters in an NMEA sentence but the decimal seconds are an optional part of the standard.