### PR TITLE
Fixed to check only sentence ID not talker ID.

### DIFF
--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -211,7 +211,7 @@ nmea_get_parser_by_sentence(const char *sentence)
 
 	for (i = 0; i < n_parsers; i++) {
 		parser = parsers[i];
-		if (0 == strncmp(sentence + 1, parser->parser.type_word, NMEA_PREFIX_LENGTH)) {
+		if (0 == strncmp(sentence + 3, parser->parser.type_word, sizeof(parsers[i].parser.type_word))) {
 			return parser;
 		}
 	}

--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -211,7 +211,7 @@ nmea_get_parser_by_sentence(const char *sentence)
 
 	for (i = 0; i < n_parsers; i++) {
 		parser = parsers[i];
-		if (0 == strncmp(sentence + 3, parser->parser.type_word, sizeof(parsers[i].parser.type_word))) {
+		if (0 == strncmp(sentence + 3, parser->parser.type_word, sizeof(parser->parser.type_word))) {
 			return parser;
 		}
 	}

--- a/src/nmea/parser_static.c
+++ b/src/nmea/parser_static.c
@@ -85,11 +85,7 @@ nmea_get_parser_by_sentence(const char *sentence)
 	int i;
 
 	for (i = 0; i < PARSER_COUNT; i++) {
-		if (NULL == parsers[i].parser.type_word) {
-			continue;
-		}
-
-		if (0 == strncmp(sentence + 1, parsers[i].parser.type_word, NMEA_PREFIX_LENGTH)) {
+		if (0 == strncmp(sentence + 3, parsers[i].parser.type_word, sizeof(parsers[i].parser.type_word))) {
 			return &(parsers[i]);
 		}
 	}

--- a/src/nmea/parser_types.h
+++ b/src/nmea/parser_types.h
@@ -5,11 +5,11 @@
 
 typedef struct {
 	nmea_t type;
-	char type_word[5];
+	char type_word[3];
 	nmea_s *data;
 } nmea_parser_s;
 
-#define NMEA_PARSER_PREFIX(parser, type_prefix) strncpy(parser->type_word, type_prefix, NMEA_PREFIX_LENGTH)
+#define NMEA_PARSER_PREFIX(parser, type_prefix) strncpy(parser->type_word, type_prefix, sizeof(parser->type_word))
 #define NMEA_PARSER_TYPE(parser, nmea_type) parser->type = nmea_type
 
 #endif  /* INC_NMEA_PARSER_TYPES_H */

--- a/src/parsers/gpgga.c
+++ b/src/parsers/gpgga.c
@@ -7,7 +7,7 @@ init(nmea_parser_s *parser)
 {
 	/* Declare what sentence type to parse */
 	NMEA_PARSER_TYPE(parser, NMEA_GPGGA);
-	NMEA_PARSER_PREFIX(parser, "GPGGA");
+	NMEA_PARSER_PREFIX(parser, "GGA");
 	return 0;
 }
 

--- a/src/parsers/gpgll.c
+++ b/src/parsers/gpgll.c
@@ -7,7 +7,7 @@ init(nmea_parser_s *parser)
 {
 	/* Declare what sentence type to parse */
 	NMEA_PARSER_TYPE(parser, NMEA_GPGLL);
-	NMEA_PARSER_PREFIX(parser, "GPGLL");
+	NMEA_PARSER_PREFIX(parser, "GLL");
 	return 0;
 }
 

--- a/src/parsers/gpgsv.c
+++ b/src/parsers/gpgsv.c
@@ -7,7 +7,7 @@ init(nmea_parser_s *parser)
 {
 	/* Declare what sentence type to parse */
 	NMEA_PARSER_TYPE(parser, NMEA_GPGSV);
-	NMEA_PARSER_PREFIX(parser, "GPGSV");
+	NMEA_PARSER_PREFIX(parser, "GSV");
 	return 0;
 }
 

--- a/src/parsers/gprmc.c
+++ b/src/parsers/gprmc.c
@@ -7,7 +7,7 @@ init(nmea_parser_s *parser)
 {
 	/* Declare what sentence type to parse */
 	NMEA_PARSER_TYPE(parser, NMEA_GPRMC);
-	NMEA_PARSER_PREFIX(parser, "GPRMC");
+	NMEA_PARSER_PREFIX(parser, "RMC");
 	return 0;
 }
 


### PR DESCRIPTION
In order to support non GPS talkers such as GLONASS (Russia), Galileo (Europe), I fixed to check only sentence ID such as GGA, RMC, etc.
