### PR TITLE
Replaced using strptime() with strtoul() to parse date and time value…

### DIFF
--- a/src/parsers/parse.c
+++ b/src/parsers/parse.c
@@ -56,6 +56,7 @@ int
 nmea_time_parse(char *s, struct tm *time)
 {
 	char *rv;
+	uint32_t x;
 
 	memset(time, 0, sizeof (struct tm));
 
@@ -63,9 +64,12 @@ nmea_time_parse(char *s, struct tm *time)
 		return -1;
 	}
 
-	rv = strptime(s, NMEA_TIME_FORMAT, time);
-	if (NULL == rv || (int) (rv - s) != NMEA_TIME_FORMAT_LEN) {
-		return -1;
+	x = strtoul(s, &rv, 10);
+	time->tm_hour = x / 10000;
+	time->tm_min = (x % 10000) / 100;
+	time->tm_sec = x % 100;
+	if (rv && *rv == '.') {
+		/* TODO There is a sub-second field. */
 	}
 
 	return 0;
@@ -75,6 +79,7 @@ int
 nmea_date_parse(char *s, struct tm *time)
 {
 	char *rv;
+	uint32_t x;
 
 	// Assume it has been already cleared
 	// memset(time, 0, sizeof (struct tm));
@@ -83,10 +88,10 @@ nmea_date_parse(char *s, struct tm *time)
 		return -1;
 	}
 
-	rv = strptime(s, NMEA_DATE_FORMAT, time);
-	if (NULL == rv || (int) (rv - s) != NMEA_DATE_FORMAT_LEN) {
-		return -1;
-	}
+	x = strtoul(s, &rv, 10);
+	time->tm_mday = x / 10000;
+	time->tm_mon = ((x % 10000) / 100) - 1;
+	time->tm_year = x % 100;
 
 	return 0;
 }

--- a/src/parsers/parse.c
+++ b/src/parsers/parse.c
@@ -68,7 +68,10 @@ nmea_time_parse(char *s, struct tm *time)
 	time->tm_hour = x / 10000;
 	time->tm_min = (x % 10000) / 100;
 	time->tm_sec = x % 100;
-	if (rv && *rv == '.') {
+	if (time->tm_hour > 23 || time->tm_min > 59 || time->tm_sec > 59 || (int) (rv - s) < NMEA_TIME_FORMAT_LEN) {
+		return -1;
+	}
+	if (*rv == '.') {
 		/* TODO There is a sub-second field. */
 	}
 


### PR DESCRIPTION
The strptime() works incorrectly on some newlib for embedded devices.
So I replaced it with strtoul(). Please check it.