### PR TITLE
Fix gpgsv struct extension offset

### DIFF
--- a/src/parsers/gpgsv.h
+++ b/src/parsers/gpgsv.h
@@ -7,6 +7,7 @@
 #include <nmea.h>
 
 typedef struct {
+	nmea_s base;
 	unsigned int sentences; //Number of sentences for full data
 	unsigned int sentence_number; //Current sentence number
 	unsigned int satellites; //Number of satellites in view


### PR DESCRIPTION
The nmea_s base element was not added to the nmea_gpgsv_s struct,
causing sentences and sentence_number to be overwritten in nmea_parse