### PR TITLE
GCC warning fixes

### DIFF
--- a/src/nmea/parser_types.h
+++ b/src/nmea/parser_types.h
@@ -5,11 +5,11 @@
 
 typedef struct {
 	nmea_t type;
-	char type_word[5];
+	char type_word[NMEA_PREFIX_LENGTH];
 	nmea_s *data;
 } nmea_parser_s;
 
-#define NMEA_PARSER_PREFIX(parser, type_prefix) strncpy(parser->type_word, type_prefix, NMEA_PREFIX_LENGTH)
+#define NMEA_PARSER_PREFIX(parser, type_prefix) memcpy(parser->type_word, type_prefix, NMEA_PREFIX_LENGTH)
 #define NMEA_PARSER_TYPE(parser, nmea_type) parser->type = nmea_type
 
 #endif  /* INC_NMEA_PARSER_TYPES_H */

--- a/src/parsers/parse.h
+++ b/src/parsers/parse.h
@@ -1,7 +1,10 @@
 #ifndef INC_NMEA_PARSE_H
 #define INC_NMEA_PARSE_H
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE /* glibc2 needs this */
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>


### PR DESCRIPTION
Hi @jacketizer, I haven't used your library since 2017, came to use it again, and happy to see you are still maintaining it :+1:.

Please consider two warning fixes, they happen when building with GCC 8.4, and newlib 3.3 as the C library:

* Fix stringop-truncation GCC warning in NMEA_PARSER_PREFIX macro

  Recent versions of GCC verify that the destination of strncpy call is sufficiently long for the string and the terminating nul byte. Since the intention of the code is to copy the characters only, without the nul terminator, using memcpy is more appropriate.

* Fix redefinition of _XOPEN_SOURCE macro

  Newlib C library defines _XOPEN_SOURCE macro in features.h:
  ```c++
  #define _XOPEN_SOURCE 700
  ```
  This definition gets pulled in through most of the standard headers.
  Since the definition in parse.h is different, the preprocessor complains.

  Fix by guarding the definition.


### Testing

Tested in `ubuntu:20.04` docker image, all passed without errors or warnings:

* apt-get update && apt-get install -y build-essential cmake
* make
* make install
* make unit-tests
* make system-tests
* mkdir cmake-build && cd cmake-build && cmake .. && make
* bin/utests
* bin/utests-nmea 
* bin/minimum 
* bin/utests-parse 