### PR TITLE
Repair CI builds by moving to Github Actions

### DIFF
--- a/.github/workflows/builds_and_tests.yml
+++ b/.github/workflows/builds_and_tests.yml
@@ -1,0 +1,26 @@
+# This name is also used in the status badge
+name: builds and tests
+
+on: [push, pull_request]
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v2
+    - name: Build and test with make
+      run: |
+        make
+        sudo make install
+        make unit-tests
+        make system-tests
+    - name: Build and test with CMake
+      run: |
+        mkdir -p cmake-build && cd cmake-build
+        cmake ..
+        make
+        bin/utests
+        bin/utests-nmea
+        bin/minimum
+        bin/utests-parse

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: c
-install: make
-script:
-  - make system-tests
-  - make unit-tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # C Library for Parsing NMEA 0183 Sentences
 
-[![Build Status](https://travis-ci.org/jacketizer/libnmea.svg?branch=master)](https://travis-ci.org/jacketizer/libnmea)
-[![Memory Leaks](https://img.shields.io/badge/memory%20leaks-0%20bytes-brightgreen.svg)](https://travis-ci.org/jacketizer/libnmea)
+[![Build Status](https://github.com/jacketizer/libnmea/workflows/builds%20and%20tests/badge.svg)](https://github.com/jacketizer/libnmea/actions?query=workflow%3A%22builds+and+tests%22+branch%3Amaster)
+![Memory Leaks](https://img.shields.io/badge/memory%20leaks-0%20bytes-brightgreen.svg)
 [![License](https://img.shields.io/npm/l/express.svg)](https://raw.githubusercontent.com/jacketizer/libnmea/master/LICENSE)
 
 Libnmea is a lightweight C library that parses NMEA 0183 sentence strings into


### PR DESCRIPTION
Travis CI hasn't been working in the repository for a while, since the end of 2018. Given that CI for public repositories is [subject to a limited "credits" allocation, that has to be requested from Travis for each project](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing), it seems that the easiest option is to switch to using Github Actions. Github Actions is limited to 2000 minutes per month for free accounts ([docs](https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)), but this shouldn't be an issue for this repository.

This PR adds a simple Github workflow file, which builds the library with make and CMake, and runs the tests. The README.md file is updated to point to the new build status badge ([preview](https://github.com/igrr/libnmea/blob/master/README.md)).

Having working CI in the repository should allow for easier merging of other PRs.

Should this PR get approved, there are some other things I'd like to propose, like enabling `-Wall -Wextra -Werror` in CI builds, building with sanitizers, etc.