### PR TITLE
Enable -Werror, fix related warnings, fixes for PARSER_PATH

### DIFF
--- a/.github/workflows/builds_and_tests.yml
+++ b/.github/workflows/builds_and_tests.yml
@@ -9,18 +9,19 @@ jobs:
     steps:
     - name: Check out the repository
       uses: actions/checkout@v2
+    - name: Build and test with CMake
+      run: |
+        mkdir -p cmake-build && cd cmake-build
+        cmake ..
+        make
+        export NMEA_PARSER_PATH=$PWD/parsers/
+        bin/utests
+        bin/utests-nmea
+        bin/minimum
+        bin/utests-parse
     - name: Build and test with make
       run: |
         make
         sudo make install
         make unit-tests
         make system-tests
-    - name: Build and test with CMake
-      run: |
-        mkdir -p cmake-build && cd cmake-build
-        cmake ..
-        make
-        bin/utests
-        bin/utests-nmea
-        bin/minimum
-        bin/utests-parse

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if (NMEA_BUILD_SHARED_LIB)
     endif()
 
     install(TARGETS nmea_shared DESTINATION lib)
+    target_compile_definitions(nmea_shared PRIVATE -DPARSER_PATH="${CMAKE_INSTALL_PREFIX}/lib/nmea/")
 
     if (POLICY CMP0042)
         cmake_policy(POP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ if (NOT NMEA_BUILD_STATIC_LIB)
     set(NMEA_UNIT_TESTS_LINK_STATIC OFF)
 endif()
 
+# Set default warning flags for all targets in this directory
+add_compile_options(-Wall -Werror)
+
 # Set some nicer output dirs.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SRC_EXAMPLES := $(shell find examples/ -type f -name "*.c")
 BIN_EXAMPLES := $(patsubst %.c, %, $(SRC_EXAMPLES))
 
 CC := gcc
-CFLAGS := -c -fPIC -g -Wall
+CFLAGS := -c -fPIC -g -Wall -Werror
 LDFLAGS := -shared -fvisibility=hidden -Wl,--exclude-libs=ALL,--no-as-needed,-soname,libnmea.so -Wall -g
 LDFLAGS_DL := -ldl
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ src/parsers/%: src/parsers/%.c $(OBJ_PARSER_DEP)
 
 %.o: %.c
 	$(CC) $(CFLAGS) -MM $< > $(patsubst %.o,%.d,$@)
-	$(CC) $(CFLAGS) -DPARSER_PATH=$(PREFIX)/lib/nmea/ $< -o $@
+	$(CC) $(CFLAGS) -DPARSER_PATH=\"$(PREFIX)/lib/nmea/\" $< -o $@
 endif
 # ifdef NMEA_STATIC
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ export C_INCLUDE_PATH="<prefix>/include"
 export LD_LIBRARY_PATH="<prefix>/lib"
 ```
 
+Additionally, set `NMEA_PARSER_PATH` variable before running the program:
+```sh
+export NMEA_PARSER_PATH="<prefix>/lib/nmea/"
+```
+Note that the trailing slash is required!
+
 ## How to use it
 
 First, include *nmea.h* and the header files for the desired sentence types:

--- a/src/nmea/nmea.c
+++ b/src/nmea/nmea.c
@@ -98,6 +98,9 @@ void nmea_cleanup()
 nmea_t
 nmea_get_type(const char *sentence)
 {
+	if (NULL == sentence) {
+		return NMEA_UNKNOWN;
+	}
 	nmea_parser_module_s *parser = nmea_get_parser_by_sentence(sentence);
 	if (NULL == parser) {
 		return NMEA_UNKNOWN;

--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -10,7 +10,10 @@ nmea_parser_module_s **parsers;
  * Where to find the parser modules.
  * Can be overridden by env variable NMEA_PARSER_PATH
  */
+#ifndef PARSER_PATH
 #define PARSER_PATH "/usr/lib/nmea/"
+#endif
+
 #define FILENAME_MAX 255
 
 static int

--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -210,6 +210,10 @@ nmea_get_parser_by_sentence(const char *sentence)
 	int i;
 	nmea_parser_module_s *parser;
 
+	if (0 == strlen(sentence)) {
+		return (nmea_parser_module_s *) NULL;
+	}
+
 	for (i = 0; i < n_parsers; i++) {
 		parser = parsers[i];
 		if (0 == strncmp(sentence + 1, parser->parser.type_word, NMEA_PREFIX_LENGTH)) {

--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -148,8 +148,6 @@ nmea_load_parsers()
 	if (NULL == parser_path) {
 		/* Use default path */
 		parser_path = PARSER_PATH;
-	} else {
-		parser_path = parser_path;
 	}
 
 	n_parsers = _get_so_files(parser_path, files);

--- a/src/nmea/parser_static.c
+++ b/src/nmea/parser_static.c
@@ -85,10 +85,6 @@ nmea_get_parser_by_sentence(const char *sentence)
 	int i;
 
 	for (i = 0; i < PARSER_COUNT; i++) {
-		if (NULL == parsers[i].parser.type_word) {
-			continue;
-		}
-
 		if (0 == strncmp(sentence + 1, parsers[i].parser.type_word, NMEA_PREFIX_LENGTH)) {
 			return &(parsers[i]);
 		}

--- a/tests/unit-tests/test_lib.c
+++ b/tests/unit-tests/test_lib.c
@@ -234,7 +234,7 @@ test_parse_invalid()
 
 	sentence = strdup("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*FF\r\n");
 	res = nmea_parse(sentence, strlen(sentence), 1);
-	mu_assert("should return NULL when checksum is invalid", NULL != res);
+	mu_assert("should return NULL when checksum is invalid", NULL == res);
 	free(sentence);
 	nmea_free(res);
 
@@ -252,7 +252,6 @@ test_parse_invalid()
 
 	res = nmea_parse(NULL, 0, 1);
 	mu_assert("should return NULL when sentence is NULL", NULL == res);
-	free(sentence);
 	nmea_free(res);
 
 	return 0;
@@ -285,6 +284,7 @@ all_tests()
 	mu_group("nmea_parse()");
 	mu_run_test(test_parse_ok);
 	mu_run_test(test_parse_unknown);
+	mu_run_test(test_parse_invalid);
 	return 0;
 }
 

--- a/tests/unit-tests/test_nmea_helpers.c
+++ b/tests/unit-tests/test_nmea_helpers.c
@@ -59,25 +59,25 @@ test_crop_sentence_ok()
 	/* With checksum */
 	test_str = strdup("$GPGGA,ENGQVIST,JOHANSSON,89*D1\r\n");
 	rv = _crop_sentence(test_str, strlen(test_str));
-	mu_assert("should return a cropped string", 0 == strcmp(rv, strdup("ENGQVIST,JOHANSSON,89")));
+	mu_assert("should return a cropped string", 0 == strcmp(rv, "ENGQVIST,JOHANSSON,89"));
 	free(test_str);
 
 	/* Without checksum */
 	test_str = strdup("$GPGGA,ENGQVIST,JOHANSSON,89\r\n");
 	rv = _crop_sentence(test_str, strlen(test_str));
-	mu_assert("should return a cropped string without checksum", 0 == strcmp(rv, strdup("ENGQVIST,JOHANSSON,89")));
+	mu_assert("should return a cropped string without checksum", 0 == strcmp(rv, "ENGQVIST,JOHANSSON,89"));
 	free(test_str);
 
 	/* Empty values */
 	test_str = strdup("$GPGGA,,ENGQVIST,,JOHANSSON,,89,,\r\n");
 	rv = _crop_sentence(test_str, strlen(test_str));
-	mu_assert("should work with empty values", 0 == strcmp(rv, strdup(",ENGQVIST,,JOHANSSON,,89,,")));
+	mu_assert("should work with empty values", 0 == strcmp(rv, ",ENGQVIST,,JOHANSSON,,89,,"));
 	free(test_str);
 
 	/* Empty values and checksum */
 	test_str = strdup("$GPGGA,,ENGQVIST,,JOHANSSON,,89,,*1D\r\n");
 	rv = _crop_sentence(test_str, strlen(test_str));
-	mu_assert("should work with empty values and checksum", 0 == strcmp(rv, strdup(",ENGQVIST,,JOHANSSON,,89,,")));
+	mu_assert("should work with empty values and checksum", 0 == strcmp(rv, ",ENGQVIST,,JOHANSSON,,89,,"));
 	free(test_str);
 
 	return 0;


### PR DESCRIPTION
1. This PR enables `-Werror` flag when building the library, examples, and tests. `-Wall` which was missing in CMake is also added. The warnings found after enabling these flags are fixed:
   - `parser_path = parser_path;` assignment in parser.c (-Wself-assign)
   - `NULL == parsers[i].parser.type_word` in parser_static.c (-Wtautological-pointer-compare, since type_word array address can never be NULL)
   - `test_parse_invalid` in test_lib.c never invoked
   - `PARSER_PATH` redefinition in parser.c — it was also defined on the command line. Once this was fixed, it turned out that:
     -  `PARSER_PATH` definition on the command line (in Make) was missing quotes around the string constant.
     -  `PARSER_PATH` was not defined in CMakeLists.txt the same way it was defined in Make.

      Both issues were also fixed.
2. A note about NMEA_PARSER_PATH variable is added to readme file (#42).

Note that while -Wall -Werror is now enabled  in CMake for all the files (library, example, tests), this is not the case in Make. Makefile does not use `CFLAGS` consistently for all the `CC` invocations, so some sources are compiled without `-Wall -Werror`.

I started cleaning this up, but then ran into the problem that I can't compile with Make on macOS at all, due to the usage of linker flags such as `--no-as-needed`, `-soname`, `--exclude-libs=ALL`, none of which is supported on macOS. Curiously, these flags are not present in CMakeLists.txt.

I have opted not to add these flags to CMakeLists.txt, to keep at least that useable on macOS :). For the time being I have dropped the attempt to fix CFLAGS inconsistencies in the Makefile.