### PR TITLE
Reformat some of the source files to KNF

### DIFF
--- a/examples/parse_stdin.c
+++ b/examples/parse_stdin.c
@@ -109,65 +109,63 @@ main(void)
 		/* handle data */
 		data = nmea_parse(start, end - start + 1, 0);
 		if (NULL != data) {
-		  if (0 < data->errors) {
-		  	printf("WARN: The sentence struct contains parse errors!\n");
-		  }
-
-		  if (NMEA_GPGGA == data->type) {
-		  	printf("GPGGA sentence\n");
-		  	nmea_gpgga_s *gpgga = (nmea_gpgga_s *) data;
-		  	printf("Number of satellites: %d\n", gpgga->n_satellites);
-		  	printf("Altitude: %f %c\n", gpgga->altitude, gpgga->altitude_unit);
-		  }
-
-		  if (NMEA_GPGLL == data->type) {
-		  	printf("GPGLL sentence\n");
-		  	nmea_gpgll_s *pos = (nmea_gpgll_s *) data;
-		  	printf("Longitude:\n");
-		  	printf("  Degrees: %d\n", pos->longitude.degrees);
-		  	printf("  Minutes: %f\n", pos->longitude.minutes);
-		  	printf("  Cardinal: %c\n", (char) pos->longitude.cardinal);
-		  	printf("Latitude:\n");
-		  	printf("  Degrees: %d\n", pos->latitude.degrees);
-		  	printf("  Minutes: %f\n", pos->latitude.minutes);
-		  	printf("  Cardinal: %c\n", (char) pos->latitude.cardinal);
-		  	strftime(buf, sizeof(buf), "%H:%M:%S", &pos->time);
-		  	printf("Time: %s\n", buf);
-		  }
-
-		  if (NMEA_GPRMC == data->type) {
-		  	printf("GPRMC sentence\n");
-		  	nmea_gprmc_s *pos = (nmea_gprmc_s *) data;
-		  	printf("Longitude:\n");
-		  	printf("  Degrees: %d\n", pos->longitude.degrees);
-		  	printf("  Minutes: %f\n", pos->longitude.minutes);
-		  	printf("  Cardinal: %c\n", (char) pos->longitude.cardinal);
-		  	printf("Latitude:\n");
-		  	printf("  Degrees: %d\n", pos->latitude.degrees);
-		  	printf("  Minutes: %f\n", pos->latitude.minutes);
-		  	printf("  Cardinal: %c\n", (char) pos->latitude.cardinal);
-		  	strftime(buf, sizeof(buf), "%d %b %T %Y", &pos->date_time);
-		  	printf("Date & Time: %s\n", buf);
-		  	printf("Speed, in Knots: %f:\n", pos->gndspd_knots);
-		  	printf("Track, in degrees: %f\n", pos->track_deg);
-		  	printf("Magnetic Variation:\n");
-		  	printf("  Degrees: %f\n", pos->magvar_deg);
-		  	printf("  Cardinal: %c\n", (char) pos->magvar_cardinal);
-		  	double adjusted_course = pos->track_deg;            
-		  	if (NMEA_CARDINAL_DIR_EAST == pos->magvar_cardinal) {
-		  		adjusted_course -= pos->magvar_deg;
-			}
-		  	else if (NMEA_CARDINAL_DIR_WEST == pos->magvar_cardinal) {
-		  		adjusted_course += pos->magvar_deg;
-			}
-		  	else {
-		  		printf("Invalid Magnetic Variation Direction!!\n");
+			if (0 < data->errors) {
+				printf("WARN: The sentence struct contains parse errors!\n");
 			}
 
-		  	printf("Adjusted Track (heading): %f\n", adjusted_course);
-		  }
+			if (NMEA_GPGGA == data->type) {
+				printf("GPGGA sentence\n");
+				nmea_gpgga_s *gpgga = (nmea_gpgga_s *) data;
+				printf("Number of satellites: %d\n", gpgga->n_satellites);
+				printf("Altitude: %f %c\n", gpgga->altitude, gpgga->altitude_unit);
+			}
 
-		  nmea_free(data);
+			if (NMEA_GPGLL == data->type) {
+				printf("GPGLL sentence\n");
+				nmea_gpgll_s *pos = (nmea_gpgll_s *) data;
+				printf("Longitude:\n");
+				printf("  Degrees: %d\n", pos->longitude.degrees);
+				printf("  Minutes: %f\n", pos->longitude.minutes);
+				printf("  Cardinal: %c\n", (char) pos->longitude.cardinal);
+				printf("Latitude:\n");
+				printf("  Degrees: %d\n", pos->latitude.degrees);
+				printf("  Minutes: %f\n", pos->latitude.minutes);
+				printf("  Cardinal: %c\n", (char) pos->latitude.cardinal);
+				strftime(buf, sizeof(buf), "%H:%M:%S", &pos->time);
+				printf("Time: %s\n", buf);
+			}
+
+			if (NMEA_GPRMC == data->type) {
+				printf("GPRMC sentence\n");
+				nmea_gprmc_s *pos = (nmea_gprmc_s *) data;
+				printf("Longitude:\n");
+				printf("  Degrees: %d\n", pos->longitude.degrees);
+				printf("  Minutes: %f\n", pos->longitude.minutes);
+				printf("  Cardinal: %c\n", (char) pos->longitude.cardinal);
+				printf("Latitude:\n");
+				printf("  Degrees: %d\n", pos->latitude.degrees);
+				printf("  Minutes: %f\n", pos->latitude.minutes);
+				printf("  Cardinal: %c\n", (char) pos->latitude.cardinal);
+				strftime(buf, sizeof(buf), "%d %b %T %Y", &pos->date_time);
+				printf("Date & Time: %s\n", buf);
+				printf("Speed, in Knots: %f:\n", pos->gndspd_knots);
+				printf("Track, in degrees: %f\n", pos->track_deg);
+				printf("Magnetic Variation:\n");
+				printf("  Degrees: %f\n", pos->magvar_deg);
+				printf("  Cardinal: %c\n", (char) pos->magvar_cardinal);
+				double adjusted_course = pos->track_deg;
+				if (NMEA_CARDINAL_DIR_EAST == pos->magvar_cardinal) {
+					adjusted_course -= pos->magvar_deg;
+				} else if (NMEA_CARDINAL_DIR_WEST == pos->magvar_cardinal) {
+					adjusted_course += pos->magvar_deg;
+				} else {
+					printf("Invalid Magnetic Variation Direction!!\n");
+				}
+
+				printf("Adjusted Track (heading): %f\n", adjusted_course);
+			}
+
+			nmea_free(data);
 		}
 
 		/* buffer empty? */

--- a/src/nmea/nmea.c
+++ b/src/nmea/nmea.c
@@ -231,7 +231,7 @@ nmea_parse(char *sentence, size_t length, int check_checksum)
 	/* Crop sentence from type word and checksum */
 	val_string = _crop_sentence(sentence, length);
 	if (NULL == val_string) {
-	      	return (nmea_s *) NULL;
+		return (nmea_s *) NULL;
 	}
 
 	/* Split the sentence into values */

--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -37,7 +37,7 @@ _get_so_files(const char *path, char **files)
 
 		len = strlen(dir->d_name);
 
-		#ifdef __APPLE__
+#ifdef __APPLE__
 		if (len < 6) {
 			continue;
 		}
@@ -45,7 +45,7 @@ _get_so_files(const char *path, char **files)
 		if (0 != strncmp(dir->d_name + len - 6, ".dylib", 6)) {
 			continue;
 		}
-		#else
+#else
 		if (len < 3) {
 			continue;
 		}
@@ -53,7 +53,7 @@ _get_so_files(const char *path, char **files)
 		if (0 != strncmp(dir->d_name + len - 3, ".so", 3)) {
 			continue;
 		}
-		#endif
+#endif
 
 		name = malloc(FILENAME_MAX);
 		if (NULL == name) {
@@ -100,7 +100,7 @@ nmea_init_parser(const char *filename)
 		return (nmea_parser_module_s *) NULL;
 	}
 
- 	parser->handle = plugin;
+	parser->handle = plugin;
 
 	init = dlsym(plugin, "init");
 	if (NULL == init) {

--- a/src/parsers/gpgsa.c
+++ b/src/parsers/gpgsa.c
@@ -44,65 +44,65 @@ parse(nmea_parser_s *parser, char *value, int val_index)
 	nmea_gpgsa_s *data = (nmea_gpgsa_s *) parser->data;
 
 	switch (val_index) {
-		case NMEA_GPGSA_MODE:
-			data->mode = *value;
-			if (('M' != toupper(data->mode)) && ('A' != toupper(data->mode))) {
-				return -1;
-			}
-			break;
-		case NMEA_GPGSA_FIXTYPE:
-			data->fixtype = strtol(value, NULL, 10);
-			if ((1 != data->fixtype) && (2 != data->fixtype) && (3 != data->fixtype)) {
-				return -1;
-			}
-			break;
-		case NMEA_GPGSA_SATID_00:
-			data->satID_00 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_01:
-			data->satID_01 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_02:
-			data->satID_02 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_03:
-			data->satID_03 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_04:
-			data->satID_04 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_05:
-			data->satID_05 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_06:
-			data->satID_06 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_07:
-			data->satID_07 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_08:
-			data->satID_08 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_09:
-			data->satID_09 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_10:
-			data->satID_10 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_SATID_11:
-			data->satID_11 = strtol(value, NULL, 10);
-			break;
-		case NMEA_GPGSA_PDOP:
-			data->pdop = strtod(value, NULL);
-			break;
-		case NMEA_GPGSA_HDOP:
-			data->hdop = strtod(value, NULL);
-			break;
-		case NMEA_GPGSA_VDOP:
-			data->vdop = strtod(value, NULL);
-			break;
-		default:
-			break;
+	case NMEA_GPGSA_MODE:
+		data->mode = *value;
+		if (('M' != toupper(data->mode)) && ('A' != toupper(data->mode))) {
+			return -1;
+		}
+		break;
+	case NMEA_GPGSA_FIXTYPE:
+		data->fixtype = strtol(value, NULL, 10);
+		if ((1 != data->fixtype) && (2 != data->fixtype) && (3 != data->fixtype)) {
+			return -1;
+		}
+		break;
+	case NMEA_GPGSA_SATID_00:
+		data->satID_00 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_01:
+		data->satID_01 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_02:
+		data->satID_02 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_03:
+		data->satID_03 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_04:
+		data->satID_04 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_05:
+		data->satID_05 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_06:
+		data->satID_06 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_07:
+		data->satID_07 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_08:
+		data->satID_08 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_09:
+		data->satID_09 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_10:
+		data->satID_10 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_SATID_11:
+		data->satID_11 = strtol(value, NULL, 10);
+		break;
+	case NMEA_GPGSA_PDOP:
+		data->pdop = strtod(value, NULL);
+		break;
+	case NMEA_GPGSA_HDOP:
+		data->hdop = strtod(value, NULL);
+		break;
+	case NMEA_GPGSA_VDOP:
+		data->vdop = strtod(value, NULL);
+		break;
+	default:
+		break;
 	}
 
 	return 0;

--- a/src/parsers/gptxt.c
+++ b/src/parsers/gptxt.c
@@ -40,7 +40,7 @@ int
 parse(nmea_parser_s *parser, char *value, int val_index)
 {
 	nmea_gptxt_s *data = (nmea_gptxt_s *) parser->data;
-  
+
 	memset(data->text, 0, NMEA_GPTXT_TEXT_SIZE);
 
 	switch (val_index) {

--- a/src/parsers/gpvtg.c
+++ b/src/parsers/gpvtg.c
@@ -42,17 +42,17 @@ parse(nmea_parser_s *parser, char *value, int val_index)
 	nmea_gpvtg_s *data = (nmea_gpvtg_s *) parser->data;
 
 	switch (val_index) {
-		case NMEA_GPVTG_TRACKGOOD:
-			data->track_deg = strtod(value, NULL);
-			break;
-		case NMEA_GPVTG_GNDSPD_KNOTS:
-			data->gndspd_knots = strtod(value, NULL);
-			break;
-		case NMEA_GPVTG_GNDSPD_KMPH:
-			data->gndspd_kmph = strtod(value, NULL);
-			break;
-		default:
-			break;
+	case NMEA_GPVTG_TRACKGOOD:
+		data->track_deg = strtod(value, NULL);
+		break;
+	case NMEA_GPVTG_GNDSPD_KNOTS:
+		data->gndspd_knots = strtod(value, NULL);
+		break;
+	case NMEA_GPVTG_GNDSPD_KMPH:
+		data->gndspd_kmph = strtod(value, NULL);
+		break;
+	default:
+		break;
 	}
 
 	return 0;

--- a/src/parsers/parse.c
+++ b/src/parsers/parse.c
@@ -97,8 +97,7 @@ nmea_date_parse(char *s, struct tm *date)
 	// Normalize tm_year according to C standard library
 	if (date->tm_year > 1900) { // ZDA message case
 		date->tm_year -= TM_YEAR_START;
-	}
-	else { // RMC message case
+	} else { // RMC message case
 		date->tm_year += (RMC_YEAR_START - TM_YEAR_START);
 	}
 


### PR DESCRIPTION
Was making a small example update and ran into inconsistent formatting. Since the main README.md clearly specifies "KNF with tabs" as the style, I think it is appropriate to fix the formatting where it differs.

I wasn't able to get the correct formatting using the `indent` command mentioned in the readme. Have tried both `indent` on macOS and `indent` on Ubuntu 20.04. The options given in the readme produced completely different formatting. I'm not familiar enough with `indent` to find the issue, though.

Instead I have formatted with Astyle 3.1, using the following options: `--style=knf --indent=tab`. This seems to be produce overall the same formatting as in the repository right now, except for the changes here: spaces to tabs, an un-indented `case`s.
