### PR TITLE
Fix include path for ./parsers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (NMEA_BUILD_STATIC_LIB)
         src/nmea/parser_static.c
         src/parsers/parse.c)
     set_target_properties(nmea PROPERTIES VERSION ${LIBNMEA_VERSION})
-    target_include_directories(nmea INTERFACE src)
+    target_include_directories(nmea INTERFACE src/nmea src/parsers)
     if (UNIX)
         target_link_libraries(nmea ${CMAKE_DL_LIBS})
     endif()
@@ -97,7 +97,7 @@ if (NMEA_BUILD_SHARED_LIB)
 
     add_library(nmea_shared SHARED ${NMEA_SRC})
     set_target_properties(nmea_shared PROPERTIES VERSION ${LIBNMEA_VERSION})
-    target_include_directories(nmea_shared INTERFACE src)
+    target_include_directories(nmea_shared INTERFACE src/nmea src/parsers)
 
     if (UNIX)
         target_link_libraries(nmea_shared ${CMAKE_DL_LIBS})


### PR DESCRIPTION
libnmea build error was added by https://github.com/jacketizer/libnmea/pull/46 😔

Since src/parsers directory wasn't in include path, it leads to the following error while compiling libnmea:
```
src/parsers/gpgga.h:7:10: fatal error: nmea.h: No such file or directory
    7 | #include <nmea.h>
```