### PR TITLE
Make escape chars validation optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 build/
 *.d
 utests*
+
+# VSCode
+.vscode/

--- a/src/nmea/nmea.c
+++ b/src/nmea/nmea.c
@@ -135,7 +135,7 @@ nmea_has_checksum(const char *sentence, size_t length)
 }
 
 int
-nmea_validate(const char *sentence, size_t length, int check_checksum)
+nmea_validate(const char *sentence, size_t length, int check_checksum, int check_escape_chars)
 {
 	const char *n;
 
@@ -154,9 +154,11 @@ nmea_validate(const char *sentence, size_t length, int check_checksum)
 		return -1;
 	}
 
-	/* should end with \r\n, or other... */
-	if (NMEA_END_CHAR_2 != sentence[length - 1] || NMEA_END_CHAR_1 != sentence[length - 2]) {
-		return -1;
+	if (1 == check_escape_chars) {
+		/* should end with \r\n, or other... */
+		if (NMEA_END_CHAR_2 != sentence[length - 1] || NMEA_END_CHAR_1 != sentence[length - 2]) {
+			return -1;
+		}
 	}
 
 	/* should have a 5 letter, uppercase word */
@@ -210,7 +212,7 @@ nmea_free(nmea_s *data)
 }
 
 nmea_s *
-nmea_parse(char *sentence, size_t length, int check_checksum)
+nmea_parse(char *sentence, size_t length, int check_checksum, int check_escape_chars)
 {
 	unsigned int n_vals, val_index;
 	char *value, *val_string;
@@ -219,7 +221,7 @@ nmea_parse(char *sentence, size_t length, int check_checksum)
 	nmea_t type;
 
 	/* Validate sentence string */
-	if (-1 == nmea_validate(sentence, length, check_checksum)) {
+	if (-1 == nmea_validate(sentence, length, check_checksum, check_escape_chars)) {
 		return (nmea_s *) NULL;
 	}
 
@@ -227,7 +229,7 @@ nmea_parse(char *sentence, size_t length, int check_checksum)
 	if (NMEA_UNKNOWN == type) {
 		return (nmea_s *) NULL;
 	}
-
+	
 	/* Crop sentence from type word and checksum */
 	val_string = _crop_sentence(sentence, length);
 	if (NULL == val_string) {
@@ -245,7 +247,7 @@ nmea_parse(char *sentence, size_t length, int check_checksum)
 	if (NULL == parser) {
 		return (nmea_s *) NULL;
 	}
-
+	
 	/* Allocate memory for parsed data */
 	parser->allocate_data((nmea_parser_s *) parser);
 	if (NULL == parser->parser.data) {

--- a/src/nmea/nmea.h
+++ b/src/nmea/nmea.h
@@ -91,14 +91,14 @@ extern int nmea_has_checksum(const char *sentence, size_t length);
  *   - Should be between the correct length.
  *   - Should start with a dollar sign.
  *   - The next five characters should be uppercase letters.
- *   - If it has a checksum, check it.
- *   - Ends with the correct 2 characters.
+ *   - If it has a checksum, check it (optional).
+ *   - Ends with the correct 2 characters (optional).
  *
  * length is the character length of the sentence string.
  *
  * Returns 0 if sentence is valid, otherwise -1.
  */
-extern int nmea_validate(const char *sentence, size_t length, int check_checksum);
+extern int nmea_validate(const char *sentence, size_t length, int check_checksum, int check_escape_chars);
 
 /**
  * Free an nmea data struct.
@@ -116,7 +116,7 @@ extern void nmea_free(nmea_s *data);
  *
  * Returns a pointer to an NMEA data struct, or (nmea_s *) NULL if an error occurs.
  */
-extern nmea_s *nmea_parse(char *sentence, size_t length, int check_checksum);
+extern nmea_s *nmea_parse(char *sentence, size_t length, int check_checksum, int check_escape_chars);
 
 #ifdef __cplusplus
 }

--- a/tests/unit-tests/test_lib.c
+++ b/tests/unit-tests/test_lib.c
@@ -103,7 +103,7 @@ test_validate_ok_with_crc()
 {
 	// Valid sentence with checksum
 	char *sentence = strdup("$GPGLL,4916.45,N,12311.12,W,225444,A,*1D\r\n");
-	int res = nmea_validate(sentence, strlen(sentence), 1);
+	int res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return 0 when sentence is valid", 0 == res);
 	free(sentence);
 
@@ -118,13 +118,13 @@ test_validate_ok_without_crc()
 
 	// Valid sentence without checksum
 	sentence = strdup("$GPGLL,4916.45,N,12311.12,W,225444,A\r\n");
-	res = nmea_validate(sentence, strlen(sentence), 1);
+	res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return 0 when sentence is valid", 0 == res);
 	free(sentence);
 
 	// Valid sentence with invalid checksum
 	sentence = strdup("$GPGLL,4916.45,N,12311.12,W,225444,A*FF\r\n");
-	res = nmea_validate(sentence, strlen(sentence), 0);
+	res = nmea_validate(sentence, strlen(sentence), 0, 1);
 	mu_assert("should return 0 when check_checksum is 0 and crc is invalid", 0 == res);
 	free(sentence);
 
@@ -136,7 +136,7 @@ test_validate_fail_type()
 {
 	// Invalid sentence type
 	char *sentence = strdup("$GPgll,4916.45,N,12311.12,W,225444,A\r\n");
-	int res = nmea_validate(sentence, strlen(sentence), 1);
+	int res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return -1 when sentence type is invalid", -1 == res);
 	free(sentence);
 
@@ -148,7 +148,7 @@ test_validate_fail_start()
 {
 	// Invalid sentence start (no $ sign)
 	char *sentence = strdup("£GPGLL,4916.45,N,12311.12,W,225444,A\r\n");
-	int res = nmea_validate(sentence, strlen(sentence), 1);
+	int res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return -1 when sentence start is invalid", -1 == res);
 	free(sentence);
 
@@ -163,13 +163,13 @@ test_validate_fail_end()
 
 	// Invalid sentence ending (no \n)
 	sentence = strdup("$GPGLL,4916.45,N,12311.12,W,225444,A");
-	res = nmea_validate(sentence, strlen(sentence), 1);
+	res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return -1 when sentence ending is invalid", -1 == res);
 	free(sentence);
 
 	// Too short sentence
 	sentence = strdup("$GP");
-	res = nmea_validate(sentence, strlen(sentence), 1);
+	res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return -1 when sentence is too short", -1 == res);
 	free(sentence);
 
@@ -181,7 +181,7 @@ test_validate_fail_empty()
 {
 	// Invalid sentence (empty string)
 	char *sentence = strdup("");
-	int res = nmea_validate(sentence, strlen(sentence), 1);
+	int res = nmea_validate(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return -1 when sentence is empty", -1 == res);
 	free(sentence);
 
@@ -196,14 +196,14 @@ test_parse_ok()
 
 	// With crc\n
 	sentence = strdup("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n");
-	res = nmea_parse(sentence, strlen(sentence), 1);
+	res = nmea_parse(sentence, strlen(sentence), 1, 1);
 	mu_assert("should be able to parse a GPGGA sentence", NULL != res);
 	free(sentence);
 	nmea_free(res);
 
 	// With invalid crc, but check disabled
 	sentence = strdup("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*FF\r\n");
-	res = nmea_parse(sentence, strlen(sentence), 0);
+	res = nmea_parse(sentence, strlen(sentence), 0, 1);
 	mu_assert("should be able to parse a GPGGA sentence", NULL != res);
 	free(sentence);
 	nmea_free(res);
@@ -218,7 +218,7 @@ test_parse_unknown()
 	nmea_s *res;
 
 	sentence = strdup("$JACK1,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47\r\n");
-	res = nmea_parse(sentence, strlen(sentence), 1);
+	res = nmea_parse(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return NULL when sentence type is unknown", NULL == res);
 	free(sentence);
 	nmea_free(res);
@@ -233,24 +233,24 @@ test_parse_invalid()
 	nmea_s *res;
 
 	sentence = strdup("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*FF\r\n");
-	res = nmea_parse(sentence, strlen(sentence), 1);
+	res = nmea_parse(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return NULL when checksum is invalid", NULL == res);
 	free(sentence);
 	nmea_free(res);
 
 	sentence = strdup("");
-	res = nmea_parse(sentence, strlen(sentence), 1);
+	res = nmea_parse(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return NULL when sentence is empty", NULL == res);
 	free(sentence);
 	nmea_free(res);
 
 	sentence = strdup("invalid");
-	res = nmea_parse(sentence, strlen(sentence), 1);
+	res = nmea_parse(sentence, strlen(sentence), 1, 1);
 	mu_assert("should return NULL when sentence is invalid", NULL == res);
 	free(sentence);
 	nmea_free(res);
 
-	res = nmea_parse(NULL, 0, 1);
+	res = nmea_parse(NULL, 0, 1, 1);
 	mu_assert("should return NULL when sentence is NULL", NULL == res);
 	nmea_free(res);
 

--- a/tests/unit-tests/test_lib.c
+++ b/tests/unit-tests/test_lib.c
@@ -189,6 +189,17 @@ test_validate_fail_empty()
 }
 
 static char *
+test_validate_no_escape_chars()
+{
+	char *sentence = strdup("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47");
+	int res = nmea_validate(sentence, strlen(sentence), 1, 0);
+	mu_assert("shuld be able to parse sentences with no escape chars, as plain text", 0 == res);
+	free(sentence);
+
+	return 0;
+}
+
+static char *
 test_parse_ok()
 {
 	char *sentence;
@@ -280,6 +291,8 @@ all_tests()
 	mu_run_test(test_validate_fail_start);
 	mu_run_test(test_validate_fail_end);
 	mu_run_test(test_validate_fail_empty);
+
+	mu_run_test(test_validate_no_escape_chars);
 
 	mu_group("nmea_parse()");
 	mu_run_test(test_parse_ok);


### PR DESCRIPTION
## My problem

Since i have all the nmea sentences in a .txt file, one sentence in a row, the escape chars are not in plain text, so the sentence validation fails.

I am accessing the file like this:
``` c
char sentence[NMEA_MAX_LENGTH] = {0};

while(fgets(sentence, sizeof(sentence), nema_file) != NULL) {
    // Validate and do some stuff
}
```
## My solution

My solution is simply to make the check for escape chars optional.

I also modified all the test cases to match this new change, and added a new test-case to validate a sentence without escape chars 99c5b94ec6b755f21f4e45e342cc5a055de3e3fa