### PR TITLE
parsers: check only sentence ID, not talker ID

### DIFF
--- a/src/nmea/parser.c
+++ b/src/nmea/parser.c
@@ -216,7 +216,8 @@ nmea_get_parser_by_sentence(const char *sentence)
 
 	for (i = 0; i < n_parsers; i++) {
 		parser = parsers[i];
-		if (0 == strncmp(sentence + 1, parser->parser.type_word, NMEA_PREFIX_LENGTH)) {
+		/* compare only the sentence ID, ignore the talker ID */
+		if (0 == strncmp(sentence + 3, parser->parser.type_word + 2, NMEA_PREFIX_LENGTH - 2)) {
 			return parser;
 		}
 	}

--- a/src/nmea/parser_static.c
+++ b/src/nmea/parser_static.c
@@ -109,7 +109,8 @@ nmea_get_parser_by_sentence(const char *sentence)
 	int i;
 
 	for (i = 0; i < PARSER_COUNT; i++) {
-		if (0 == strncmp(sentence + 1, parsers[i].parser.type_word, NMEA_PREFIX_LENGTH)) {
+		/* compare only the sentence ID, ignore the talker ID */
+		if (0 == strncmp(sentence + 3, parsers[i].parser.type_word + 2, NMEA_PREFIX_LENGTH - 2)) {
 			return &(parsers[i]);
 		}
 	}

--- a/src/nmea/parser_types.h
+++ b/src/nmea/parser_types.h
@@ -5,6 +5,10 @@
 
 typedef struct {
 	nmea_t type;
+	/* For compatibility with older versions, type_word also contains the talker ID (e.g. "GP".)
+	 * However the talker ID is not taken account when looking for a parser. For example, the parser
+	 * with type_word="GPRMC" will also be used for a "GNRMC" sentence.
+	 */
 	char type_word[NMEA_PREFIX_LENGTH];
 	nmea_s *data;
 } nmea_parser_s;

--- a/tests/unit-tests/test_lib.c
+++ b/tests/unit-tests/test_lib.c
@@ -23,6 +23,11 @@ test_get_type_ok()
 	mu_assert("should return correct type (GPGGA)", NMEA_GPGGA == res);
 	free(sentence);
 
+	sentence = strdup("$GNGGA,4916.45,N,12311.12,W,225444,A\r\n");
+	res = nmea_get_type(sentence);
+	mu_assert("should return correct type (GPGGA) even if talker is GN", NMEA_GPGGA == res);
+	free(sentence);
+
 	return 0;
 }
 


### PR DESCRIPTION
Based on the PR https://github.com/jacketizer/libnmea/pull/33 from @jsjeong.

To support sentences sent with different talker IDs (e.g. GN instead
of GP) this PR modifies the parser matching code to only check the
3 bytes of the sentence ID.

Unlike the original PR where type_word is reduced to 3 bytes, here
it is left unchanged. This reduces the chance of breaking changes
for users who have implemented their own parsers, and prevents
binary incompatibility with shared libraries built with the previous
versions of libnmea.

Also includes a test case.